### PR TITLE
OPAM requires that the toplevel init checks `OCAML_TOPLEVEL_PATH`

### DIFF
--- a/iocaml.ml
+++ b/iocaml.ml
@@ -455,6 +455,7 @@ end
 (* main *)
 
 let () = Printf.printf "[iocaml] Starting kernel\n%!" 
+let () = Sys.interactive := false
 let () = Toploop.set_paths() 
 let () = !Toploop.toplevel_startup_hook() 
 let () = Toploop.initialize_toplevel_env() 
@@ -507,7 +508,14 @@ let () =
     if !packages <> [] then begin
         let command = 
 "
-#use \"topfind\";; 
+let () =
+  try Topdirs.dir_directory (Sys.getenv \"OCAML_TOPLEVEL_PATH\")
+  with Not_found -> ()
+;;
+
+#use \"topfind\" ;;
+#thread ;;
+#camlp4o ;;
 #require \"" ^ String.concat "," (List.rev !packages) ^ "\";;
 "
         in


### PR DESCRIPTION
The default `ocamlinit` installed by OPAM includes some logic to
add `OCAML_TOPLEVEL_PATH` to the search path.  This lets a system
installation of OCaml work with the OPAM-managed findlib packages.

This patch adds the check to the iocaml init, and also activates
`camlp4o` and `thread` (both part of the default recommended
ocamlinit so that syntax extensions will work).  Interactive mode
is disabled to suppress initialisation messages from Camlp4Top.
