### PR TITLE
Some fixes to make kernel work with latest Jupyter

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,14 +15,13 @@ PKG=iocaml-kernel.999.9.9
 # install ocaml compilers
 echo "yes" | sudo add-apt-repository ppa:$ppa
 sudo apt-get update -qq
-sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam
+sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam libffi-dev
 
 # initialize opam
 export OPAMYES=1
-opam init 
+opam init
 eval `opam config env`
 
-# add dev repo
 opam remote add iocaml-dev git://github.com/andrewray/opam.git
 opam update
 
@@ -33,6 +32,7 @@ sudo apt-get install -qq $DEPEXT
 fi
 
 # install package deps
+opam install ctypes-foreign
 opam install $PKG --deps-only
 
 # build 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -6,6 +6,7 @@ case "$OCAML_VERSION,$OPAM_VERSION" in
 4.00.1,1.1.0) ppa=avsm/ocaml40+opam11 ;;
 4.01.0,1.0.0) ppa=avsm/ocaml41+opam10 ;;
 4.01.0,1.1.0) ppa=avsm/ocaml41+opam11 ;;
+4.02.3,1.2.2) ppa=avsm/ocaml42+opam12;;
 *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
 esac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: c
 script: bash -ex .travis-ci.sh
 env:
-  - OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
+  - OCAML_VERSION=4.02.3 OPAM_VERSION=1.2.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+### Manual Testing
+This section describes how to test manually latest build during project development.
+When all steps are done to test changes in the code required to make only two things:
+
+- Recompile `make`.
+- Restart kernel in the running Jupyter notebook.
+
+#### Initial configuration
+
+- Install Jupyter. This step involves some dealing with python infrastructure. 
+  
+  Use `pip install --user --upgrade jupiter` command to install Jupyter for the current user, not system-wide. 
+  
+  It is recommend to create a python virtual environment and install Jupiter there for better isolation. Your choice depends on the confidence in Python ecosystem.
+  
+- Test that Jupyter is installed correctly. Run server `jupyter notebook`
+  
+- Now we need to install `iocaml` as a kernel for Jupyter. 
+  
+  - Go to the `iocaml` project directory.
+    
+  - Create a `kernel.son` file with the following content
+    
+    ``` 
+    {
+     "display_name": "OCaml",
+     "language": "ocaml",
+     "argv": [
+         "</path/to/the/iocaml-src-dir>/iocaml/iocaml.top",
+          "-log",
+          "iocaml.log",
+          "-object-info",
+          "-completion",
+          "-connection-file",
+          "{connection_file}"
+     ]
+    }
+    ```
+    
+  - Let Jupyter know that we have OCaml Kernel
+    
+    ``` 
+    jupyter kernelspec install --name iocaml-kernel `pwd`
+    ```
+    
+    **Important** we use `pwd` command so we should be in the `iocaml` source directory!
+    
+  - `opam install cop-index` to get support of the `-completion`
+    
+  - Ensure that you have a `ZeroMq 3.x` installed.
+    
+    - For OS X
+      
+      ``` 
+      brew tap caskroom/versions
+      brew install homebrew/versions/zeromq3
+      ```
+      
+    - For Ubuntu (recommend to use [preconfigured docker environment](https://github.com/signalpillar/ocaml-playground))
+      
+      ``` 
+      # 0) `vivid` doesn't have add-apt-repository by default, we have to install it
+      # 1) apt-get install -y --no-install-recommends software-properties-common
+      # 2)
+      add-apt-repository -y ppa:chris-lea/zeromq
+      # 3) libzmq3-dev
+      ```
+    
+  - Build `iocaml` project - `make`
+    
+  - Run Jupyter (OS X specific in part of `DYLD_LIBRARY_PATH` so it knows where to look for `dlliocaml_lib.so`)
+    
+    ``` 
+    DYLD_LIBRARY_PATH=`pwd`:$DYLD_LIBRARY_PATH \
+    && eval `opam config env` \
+    && jupyter notebook \
+    	--debug \
+        --Session.keyfile=./keyfile \
+        --notebook-dir=notebooks \
+        --no-browser
+    ```

--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -40,7 +40,6 @@ type execute_request = {
     code : string;
     silent : bool;
     store_history : bool;
-    user_variables : dyn;
     user_expressions : dyn;
     allow_stdin : bool;
 }
@@ -61,7 +60,6 @@ type execute_reply = {
     ?traceback : string list option;
     (* if execution was ok *)
     ?payload : payload list option;
-    ?er_user_variables <json name="user_variables"> : dyn option;
     ?er_user_expressions <json name="user_expressions"> : dyn option;
 }
 

--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -105,9 +105,7 @@ type object_info_reply = {
 (*********************************************************************)
 
 type complete_request = {
-    cr_text <json name="text"> : string;
-    line : string;
-    block : unit;
+    line <json name="code"> : string;
     cursor_pos : int;
 }
 

--- a/iocaml.ml
+++ b/iocaml.ml
@@ -379,6 +379,8 @@ module Shell = struct
             | History_reply(_) | Status(_) | Pyin(_) 
             | Pyout(_) | Stream(_) | Display_data(_) 
             | Clear(_) -> handle_invalid_message ()
+
+            | Comm_open -> ()
         in
 
         let rec run () = 

--- a/iocaml.ml
+++ b/iocaml.ml
@@ -306,13 +306,13 @@ module Shell = struct
                             `String (Exec.html_of_status message !output_cell_max_height) ];
                         po_metadata = `Assoc []; }))
             in
-            
+
             send_h sockets.shell msg
                 (Execute_reply {
                     status = "ok";
                     execution_count = !execution_count;
                     ename = None; evalue = None; traceback = None; payload = None;
-                    er_user_variables = None; er_user_expressions = None;
+                    er_user_expressions = None;
                 });
             List.iter (fun m -> if not !suppress_compiler then pyout m) status;
             send_iopub_u (Iopub_send_message (Status { execution_state = "idle" }));

--- a/message.ml
+++ b/message.ml
@@ -12,7 +12,7 @@ open Ipython_json_t
 open Ipython_json_j
 open Iocaml_zmq
 
-type message_content = 
+type message_content =
     (* messages received from front end *)
     | Connect_request
     | Kernel_info_request
@@ -36,8 +36,10 @@ type message_content =
     | Stream of stream
     | Clear of clear_output
     | Display_data of display_data
+    (* custom messages *)
+    | Comm_open
 
-let content_of_json hdr c = 
+let content_of_json hdr c =
     match hdr.msg_type with
     | "connect_request" -> Connect_request
     | "kernel_info_request" -> Kernel_info_request
@@ -61,6 +63,9 @@ let content_of_json hdr c =
     | "stream" -> Stream(stream_of_string c)
     | "display_data" -> Display_data(display_data_of_string c)
     | "clear_output" -> Clear(clear_output_of_string c)
+
+    | "comm_open" -> Comm_open
+
     | _ -> failwith ("content_of_json: " ^ hdr.msg_type)
 
 let json_of_content = function
@@ -87,6 +92,8 @@ let json_of_content = function
     | Clear(x) -> string_of_clear_output x
     | Display_data(x) -> string_of_display_data x
 
+    | Comm_open -> "{}"
+
 let msg_type_of_content = function
     | Connect_request -> "connect_request"
     | Kernel_info_request -> "kernel_info_request"
@@ -111,7 +118,9 @@ let msg_type_of_content = function
     | Clear(_) -> "clear_output"
     | Display_data(_) -> "display_data"
 
-type message = 
+    | Comm_open -> "comm_open"
+
+type message =
     {
         ids : string array;
         hmac : string;

--- a/message.mli
+++ b/message.mli
@@ -35,6 +35,8 @@ type message_content =
     | Stream of stream
     | Clear of clear_output
     | Display_data of display_data
+    (* custom messages *)
+    | Comm_open
 
 val content_of_json : header_info -> string -> message_content
 val json_of_content : message_content -> string


### PR DESCRIPTION
Hi, I've did several changes in iocaml to make it work with latest Jupyter.

5 commits cover the following: 
- updated type for `execute_request`
- updated type for `complete_request` 
- added stub to not fail on opening mechanism for custom messages
- fix the build (travis)
- add documentation how to test manually

I am a newbie in the OCaml world so please point me if something need to be changed. 

All these fixes I used to [build a docker image](https://github.com/signalpillar/ocaml-playground) that serves Jupyter with iocaml kernel configured.