### PR TITLE
Update iocaml to jupyter protocol version 5

### DIFF
--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -138,11 +138,25 @@ type connect_reply = {
 (* kernel information *)
 (*********************************************************************)
 
+type kernel_language_info = {
+  name : string;
+  version : string;
+  mimetype : string;
+  file_extension : string;
+  codemirror_mode : string;
+}
+
+type help_link = {
+  text : string;
+  url : string;
+}
+
 type kernel_info_reply = {
-    protocol_version : int list;
-    (* ipython_version : int * int * int * string; *)
-    language_version : int list;
-    language : string;
+    protocol_version : string;
+    implementation : string;
+    implementation_version : string;
+    language_info : kernel_language_info;
+    help_links : help_link list;
 }
 
 (*********************************************************************)

--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -25,6 +25,7 @@ type connection_info = {
 
 (* header (and parent) information in ZMQ messages *)
 type header_info = {
+    ~version: string;
     ~date : string;
     ~username : string;
     ~session : string;
@@ -187,7 +188,7 @@ type display_data = {
 (*********************************************************************)
 (*********************************************************************)
 
-type pyin = {
+type execute_input = {
     pi_code <json name="code"> : string;
     pi_execution_count <json name="execution_count"> : int;
 }
@@ -206,7 +207,7 @@ type pyout = {
 
 type stream = {
     st_name <json name="name"> : string;
-    st_data <json name="data"> : string;
+    st_text <json name="text"> : string;
 }
 
 (*********************************************************************)
@@ -214,9 +215,6 @@ type stream = {
 
 type clear_output = {
     wait : bool;
-    stdout : bool;
-    stderr : bool;
-    other : bool;
 }
 
 

--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -196,7 +196,7 @@ type execute_input = {
 (*********************************************************************)
 (*********************************************************************)
 
-type pyout = {
+type execute_result = {
     po_execution_count <json name="execution_count"> : int;
     po_data <json name="data"> : dyn;
     po_metadata <json name="metadata"> : dyn;

--- a/Ipython_json.atd
+++ b/Ipython_json.atd
@@ -67,8 +67,9 @@ type execute_reply = {
 (* object info *)
 (*********************************************************************)
 
-type object_info_request = {
-    oname : string;
+type inspect_request = {
+    code : string;
+    cursor_pos : int;
     detail_level : int;
 }
 
@@ -79,25 +80,11 @@ type arg_spec = {
     defaults : string list;
 }
 
-type object_info_reply = {
-    name : string;
-    found : bool;
-    ismagic : bool;
-    isalias : bool;
-    namespace : string;
-    type_name : string;
-    string_form : string;
-    base_class : string;
-    length : int;
-    oi_file <json name="file"> : string;
-    definition : string;
-    argspec : arg_spec;
-    init_definition : string;
-    docstring : string;
-    class_docstring : string;
-    call_def : string;
-    call_docstring : string;
-    oi_source <json name="source"> : string;
+type inspect_reply = {
+    status: string;
+    found: bool;
+    data: dyn;
+    metadata: dyn;
 }
 
 (*********************************************************************)
@@ -105,13 +92,14 @@ type object_info_reply = {
 (*********************************************************************)
 
 type complete_request = {
-    line <json name="code"> : string;
+    code : string;
     cursor_pos : int;
 }
 
 type complete_reply = {
     matches : string list;
-    matched_text : string;
+    cursor_start : int;
+    cursor_end : int;
     cr_status <json name="status"> : string;
 }
 

--- a/completion.mli
+++ b/completion.mli
@@ -10,5 +10,5 @@
 
 val init : unit -> LibIndex.t
 val complete : LibIndex.t -> Ipython_json_t.complete_request -> Ipython_json_t.complete_reply
-val info : LibIndex.t -> Ipython_json_t.object_info_request -> Ipython_json_t.object_info_reply
+val info : LibIndex.t -> Ipython_json_t.inspect_request -> Ipython_json_t.inspect_reply
 

--- a/exec.ml
+++ b/exec.ml
@@ -25,7 +25,7 @@ let get_error_loc = function
 let buffer = Buffer.create 100 
 let formatter = Format.formatter_of_buffer buffer 
 
-let run_cell_lb execution_count lb = 
+let run_cell_lb execution_count lb =
 
     let get_error_info exn = 
         Errors.report_error formatter exn;

--- a/iocaml.ml
+++ b/iocaml.ml
@@ -298,9 +298,9 @@ module Shell = struct
             let status = Exec.run_cell !execution_count e.code in
             Pervasives.flush stdout; Pervasives.flush stderr; send_iopub_u Iopub_flush;
 
-            let pyout message = 
+            let execute_result message = 
                 send_iopub_u (Iopub_send_message 
-                    (Pyout { 
+                    (Execute_result { 
                         po_execution_count = !execution_count;
                         po_data = `Assoc [ "text/html",
                             `String (Exec.html_of_status message !output_cell_max_height) ];
@@ -314,7 +314,7 @@ module Shell = struct
                     ename = None; evalue = None; traceback = None; payload = None;
                     er_user_expressions = None;
                 });
-            List.iter (fun m -> if not !suppress_compiler then pyout m) status;
+            List.iter (fun m -> if not !suppress_compiler then execute_result m) status;
             (* TODO send Status messages before/after handling *every* message *)
             send_iopub_u (Iopub_send_message (Status { execution_state = "idle" }));
         )
@@ -387,7 +387,7 @@ module Shell = struct
             | Shutdown_reply(_) | Execute_reply(_)
             | Inspect_reply(_) | Complete_reply(_)
             | History_reply(_) | Status(_) | Execute_input(_)
-            | Pyout(_) | Stream(_) | Display_data(_) 
+            | Execute_result(_) | Stream(_) | Display_data(_) 
             | Clear(_) -> handle_invalid_message ()
 
             | Comm_open -> ()

--- a/iocaml.ml
+++ b/iocaml.ml
@@ -344,11 +344,11 @@ module Shell = struct
 #endif
             ()
 
-    let object_info_request index socket msg x = 
+    let inspect_request index socket msg x =
 #if has_ocp=1
         if !object_info then
             let reply = Completion.info index x in
-            send_h socket msg (Object_info_reply reply)
+            send_h socket msg (Inspect_reply reply)
         else
 #endif
             ()
@@ -367,7 +367,7 @@ module Shell = struct
             | Kernel_info_request -> kernel_info_request sockets.shell msg
             | Execute_request(x) -> execute_request sockets send_iopub msg x 
             | Connect_request -> connect_request sockets.shell msg 
-            | Object_info_request(x) -> object_info_request index sockets.shell msg x
+            | Inspect_Request(x) -> inspect_request index sockets.shell msg x
             | Complete_request(x) -> complete_request index sockets.shell msg x
             | History_request(x) -> history_request sockets.shell msg x
             | Shutdown_request(x) -> shutdown_request sockets.shell msg x
@@ -375,7 +375,7 @@ module Shell = struct
             (* messages we should not be getting *)
             | Connect_reply(_) | Kernel_info_reply(_)
             | Shutdown_reply(_) | Execute_reply(_)
-            | Object_info_reply(_) | Complete_reply(_)
+            | Inspect_reply(_) | Complete_reply(_)
             | History_reply(_) | Status(_) | Pyin(_) 
             | Pyout(_) | Stream(_) | Display_data(_) 
             | Clear(_) -> handle_invalid_message ()

--- a/iocaml.ml
+++ b/iocaml.ml
@@ -322,9 +322,18 @@ module Shell = struct
         send socket
             (make_header { msg with
                 content = Kernel_info_reply { 
-                    protocol_version = [ 3; 2 ];
-                    language_version = [ 4; 1; 0 ];
-                    language = "ocaml";
+                    protocol_version = "5.0";
+                    implementation = "iocaml";
+                    implementation_version = "0.4.6";
+                    language_info = {
+                        name = "ocaml";
+                        version = "4.1.0";
+                        mimetype = "text/plain";
+                        file_extension = "ml";
+                        codemirror_mode = "mllike";
+                    };
+                    help_links = []; (* TODO add some helpful links about
+                                        ocaml *)
                 }
             })
 

--- a/iocaml.mli
+++ b/iocaml.mli
@@ -95,7 +95,7 @@ val send_mime : ?context:cell_context -> ?base64:bool -> string -> unit
 
 (** sends message to clear cell output area (requires IPython 2.0+) *)
 val send_clear : ?context:cell_context -> 
-    ?wait:bool -> ?stdout:bool -> ?stderr:bool -> ?other:bool -> unit -> unit
+    ?wait:bool -> unit -> unit
 
 (* get current cells context *)
 val cell_context : unit -> cell_context

--- a/message.ml
+++ b/message.ml
@@ -32,7 +32,7 @@ type message_content =
     (* others *)
     | Status of status
     | Execute_input of execute_input
-    | Pyout of pyout
+    | Execute_result of execute_result
     | Stream of stream
     | Clear of clear_output
     | Display_data of display_data
@@ -59,7 +59,7 @@ let content_of_json hdr c =
 
     | "status" -> Status(status_of_string c)
     | "execute_input" -> Execute_input(execute_input_of_string c)
-    | "pyout" -> Pyout(pyout_of_string c)
+    | "execute_result" -> Execute_result(execute_result_of_string c)
     | "stream" -> Stream(stream_of_string c)
     | "display_data" -> Display_data(display_data_of_string c)
     | "clear_output" -> Clear(clear_output_of_string c)
@@ -87,7 +87,7 @@ let json_of_content = function
 
     | Status(x) -> string_of_status x
     | Execute_input(x) -> string_of_execute_input x
-    | Pyout(x) -> string_of_pyout x
+    | Execute_result(x) -> string_of_execute_result x
     | Stream(x) -> string_of_stream x
     | Clear(x) -> string_of_clear_output x
     | Display_data(x) -> string_of_display_data x
@@ -113,7 +113,7 @@ let msg_type_of_content = function
 
     | Status(_) -> "status"
     | Execute_input(_) -> "execute_input"
-    | Pyout(_) -> "pyout"
+    | Execute_result(_) -> "execute_result"
     | Stream(_) -> "stream"
     | Clear(_) -> "clear_output"
     | Display_data(_) -> "display_data"

--- a/message.ml
+++ b/message.ml
@@ -18,7 +18,7 @@ type message_content =
     | Kernel_info_request
     | Shutdown_request of shutdown
     | Execute_request of execute_request
-    | Object_info_request of object_info_request
+    | Inspect_Request of inspect_request
     | Complete_request of complete_request
     | History_request of history_request
     (* messages sent to front end *)
@@ -26,7 +26,7 @@ type message_content =
     | Kernel_info_reply of kernel_info_reply
     | Shutdown_reply of shutdown
     | Execute_reply of execute_reply
-    | Object_info_reply of object_info_reply
+    | Inspect_reply of inspect_reply
     | Complete_reply of complete_reply
     | History_reply of history_reply
     (* others *)
@@ -45,7 +45,7 @@ let content_of_json hdr c =
     | "kernel_info_request" -> Kernel_info_request
     | "shutdown_request" -> Shutdown_request(shutdown_of_string c)
     | "execute_request" -> Execute_request(execute_request_of_string c)
-    | "object_info_request" -> Object_info_request(object_info_request_of_string c)
+    | "inspect_request" -> Inspect_Request(inspect_request_of_string c)
     | "complete_request" -> Complete_request(complete_request_of_string c)
     | "history_request" -> History_request(history_request_of_string c)
 
@@ -53,7 +53,7 @@ let content_of_json hdr c =
     | "kernel_info_reply" -> Kernel_info_reply(kernel_info_reply_of_string c)
     | "shutdown_reply" -> Shutdown_reply(shutdown_of_string c)
     | "execute_reply" -> Execute_reply(execute_reply_of_string c)
-    | "object_info_reply" -> Object_info_reply(object_info_reply_of_string c)
+    | "inspect_reply" -> Inspect_reply(inspect_reply_of_string c)
     | "complete_reply" -> Complete_reply(complete_reply_of_string c)
     | "history_reply" -> History_reply(history_reply_of_string c)
 
@@ -73,7 +73,7 @@ let json_of_content = function
     | Kernel_info_request -> "{}"
     | Shutdown_request(x) -> string_of_shutdown x
     | Execute_request(x) -> string_of_execute_request x
-    | Object_info_request(x) -> string_of_object_info_request x
+    | Inspect_Request(x) -> string_of_inspect_request x
     | Complete_request(x) -> string_of_complete_request x
     | History_request(x) -> string_of_history_request x
 
@@ -81,7 +81,7 @@ let json_of_content = function
     | Kernel_info_reply(x) -> string_of_kernel_info_reply x
     | Shutdown_reply(x) -> string_of_shutdown x
     | Execute_reply(x) -> string_of_execute_reply x
-    | Object_info_reply(x) -> string_of_object_info_reply x
+    | Inspect_reply(x) -> string_of_inspect_reply x
     | Complete_reply(x) -> string_of_complete_reply x
     | History_reply(x) -> string_of_history_reply x
 
@@ -99,7 +99,7 @@ let msg_type_of_content = function
     | Kernel_info_request -> "kernel_info_request"
     | Shutdown_request(_) -> "shutdown_request"
     | Execute_request(_) -> "execute_request"
-    | Object_info_request(_) -> "object_info_request"
+    | Inspect_Request(_) -> "inspect_request"
     | Complete_request(_) -> "complete_request"
     | History_request(_) -> "history_request"
 
@@ -107,7 +107,7 @@ let msg_type_of_content = function
     | Kernel_info_reply(_) -> "kernel_info_reply"
     | Shutdown_reply(_) -> "shutdown_reply"
     | Execute_reply(_) -> "execute_reply"
-    | Object_info_reply(_) -> "object_info_reply"
+    | Inspect_reply(_) -> "inspect_reply"
     | Complete_reply(_) -> "complete_reply"
     | History_reply(_) -> "history_reply"
 

--- a/message.ml
+++ b/message.ml
@@ -31,7 +31,7 @@ type message_content =
     | History_reply of history_reply
     (* others *)
     | Status of status
-    | Pyin of pyin
+    | Execute_input of execute_input
     | Pyout of pyout
     | Stream of stream
     | Clear of clear_output
@@ -58,7 +58,7 @@ let content_of_json hdr c =
     | "history_reply" -> History_reply(history_reply_of_string c)
 
     | "status" -> Status(status_of_string c)
-    | "pyin" -> Pyin(pyin_of_string c)
+    | "execute_input" -> Execute_input(execute_input_of_string c)
     | "pyout" -> Pyout(pyout_of_string c)
     | "stream" -> Stream(stream_of_string c)
     | "display_data" -> Display_data(display_data_of_string c)
@@ -86,7 +86,7 @@ let json_of_content = function
     | History_reply(x) -> string_of_history_reply x
 
     | Status(x) -> string_of_status x
-    | Pyin(x) -> string_of_pyin x
+    | Execute_input(x) -> string_of_execute_input x
     | Pyout(x) -> string_of_pyout x
     | Stream(x) -> string_of_stream x
     | Clear(x) -> string_of_clear_output x
@@ -112,7 +112,7 @@ let msg_type_of_content = function
     | History_reply(_) -> "history_reply"
 
     | Status(_) -> "status"
-    | Pyin(_) -> "pyin"
+    | Execute_input(_) -> "execute_input"
     | Pyout(_) -> "pyout"
     | Stream(_) -> "stream"
     | Clear(_) -> "clear_output"

--- a/message.mli
+++ b/message.mli
@@ -31,7 +31,7 @@ type message_content =
     (* other *)
     | Status of status
     | Execute_input of execute_input
-    | Pyout of pyout
+    | Execute_result of execute_result
     | Stream of stream
     | Clear of clear_output
     | Display_data of display_data

--- a/message.mli
+++ b/message.mli
@@ -30,7 +30,7 @@ type message_content =
     | History_reply of history_reply
     (* other *)
     | Status of status
-    | Pyin of pyin
+    | Execute_input of execute_input
     | Pyout of pyout
     | Stream of stream
     | Clear of clear_output

--- a/message.mli
+++ b/message.mli
@@ -17,7 +17,7 @@ type message_content =
     | Kernel_info_request
     | Shutdown_request of shutdown
     | Execute_request of execute_request
-    | Object_info_request of object_info_request
+    | Inspect_Request of inspect_request
     | Complete_request of complete_request
     | History_request of history_request
     (* messages sent to front end *)
@@ -25,7 +25,7 @@ type message_content =
     | Kernel_info_reply of kernel_info_reply
     | Shutdown_reply of shutdown
     | Execute_reply of execute_reply
-    | Object_info_reply of object_info_reply
+    | Inspect_reply of inspect_reply
     | Complete_reply of complete_reply
     | History_reply of history_reply
     (* other *)


### PR DESCRIPTION
This updates `iocaml` to the latest jupyter protocol, which is defined [here](http://jupyter-client.readthedocs.io/en/latest/messaging.html).
I tried to break the changes into logical bits -- you can look at the individual commits for a less noisy view. The two big changes affect the `object_info` and `kernel_info` messages, and then there are a variety of smaller changes as well.