### PR TITLE
Quiter, more readable makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,31 @@
 
 all: top
 
+MAGENTA=\x1b[35m
+PLAIN=\x1b[0m
+
 json:
-	atdgen -t Ipython_json.atd
-	atdgen -j Ipython_json.atd
+	@echo "\t$(MAGENTA)[[ generate JSON parsing ]]$(PLAIN)"
+	@atdgen -t Ipython_json.atd
+	@atdgen -j Ipython_json.atd
 
 stub:
-	ocamlfind c iocaml_zmq_stubs.c
+	@ocamlfind c iocaml_zmq_stubs.c
 
 lib: json stub
-	# compile log (first so we can use it in the zmq code)
-	ocamlfind c -c -g log.mli log.ml
-	# iocaml_zmq (which requires preprocessing)
-	ocamlfind c -c -g \
+	@echo "\t$(MAGENTA)[[ build iocaml_lib ]]$(PLAIN)"
+	@# compile log (first so we can use it in the zmq code)
+	@ocamlfind c -c -g log.mli log.ml
+	@# iocaml_zmq (which requires preprocessing)
+	@ocamlfind c -c -g \
 		-syntax camlp4o -package lwt.unix,lwt.syntax,ctypes.foreign \
 		iocaml_zmq.mli iocaml_zmq.ml  
-	# rest of the library
-	ocamlfind c -c -g \
+	@# rest of the library
+	@ocamlfind c -c -g \
 		-package yojson,atdgen,compiler-libs \
 		Ipython_json_t.mli Ipython_json_j.mli base64.mli \
 		Ipython_json_t.ml  Ipython_json_j.ml  base64.ml  
-	ocamlfind ocamlmklib -o iocaml_lib \
+	@ocamlfind ocamlmklib -o iocaml_lib \
 		-l zmq \
 		-package ctypes.foreign,lwt.unix,yojson \
 		iocaml_zmq_stubs.o \
@@ -48,30 +53,32 @@ TOP_OCP =
 endif
 
 top: lib
-	ocamlfind c -c -g -thread \
+	@echo "\t$(MAGENTA)[[ build iocaml.top ]]$(PLAIN)"
+	@ocamlfind c -c -g -thread \
 		-syntax camlp4o -package optcomp -ppopt "-let has_ocp=$(HAS_OCP)" \
 		-package $(TOP_PKG) \
 		$(TOP_OCP) $(TOP_SRC)
-	ocamlfind ocamlmktop -g -thread -linkpkg \
+	@ocamlfind ocamlmktop -g -thread -linkpkg \
 		-o iocaml.top \
 		-package $(TOP_PKG) $(TOP_OCP) \
 		iocaml_lib.cma $(TOP_OBJ) iocaml_main.ml
+	@echo "\t$(MAGENTA)>> iocaml.top built successfully <<$(PLAIN)"
 
 BINDIR=`opam config var bin`
 
 install: top
-	ocamlfind install iocaml-kernel META *.cmi *.cmo *.cma *.so *.a *.o
-	cp iocaml.top $(BINDIR)/iocaml.top
+	@ocamlfind install iocaml-kernel META *.cmi *.cmo *.cma *.so *.a *.o
+	@cp iocaml.top $(BINDIR)/iocaml.top
 
 uninstall:
-	ocamlfind remove iocaml-kernel
-	rm -f $(BINDIR)/iocaml.top
+	@ocamlfind remove iocaml-kernel
+	@rm -f $(BINDIR)/iocaml.top
 
 reinstall:
-	-$(MAKE) uninstall
-	$(MAKE) install
+	@-$(MAKE) uninstall
+	@$(MAKE) install
 
 clean:
-	rm *.cmi *.cmo *.cma *.so *.a *.o iocaml.top
+	@rm *.cmi *.cmo *.cma *.so *.a *.o iocaml.top
 
 


### PR DESCRIPTION
Makefile command echoing is now silenced, and major targets echo a colored
status message to ease reading of output logs.

(I find it easier to read / understand errors, etc this way)

Test Plan:
`make`

![image](https://cloud.githubusercontent.com/assets/112170/16523689/f32787d4-3f61-11e6-954d-81000cacfeb7.png)
